### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -83,12 +83,25 @@
       {
         "url": "https://api.monday.com/v2",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "access_token": {
+            "header": ["Authorization"]
+          }
+        }
       },
       {
         "url": "https://auth.monday.com/oauth2/token",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "client_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       }
     ]
   }


### PR DESCRIPTION
This pull request updates the API configuration in the `manifest.json` file to improve how sensitive settings are injected into outgoing requests. The main changes introduce a new `settingsInjection` field for both the Monday.com API and OAuth token endpoints, enabling automatic injection of authentication and client credentials.

**API authentication improvements:**

* Added a `settingsInjection` field to the Monday.com API configuration to automatically inject the `access_token` into the `Authorization` header for requests.

**OAuth credential handling enhancements:**

* Added a `settingsInjection` field to the OAuth token endpoint configuration to automatically inject the `client_id` and `client_secret` into the request body for authentication.